### PR TITLE
read_serial: use `closePort` instead of `close`

### DIFF
--- a/utils/read_serial.go
+++ b/utils/read_serial.go
@@ -32,7 +32,7 @@ func main() {
 	}
 
 	// close properly the stream when ctrl+c is hit
-	close(stream)
+	closePort(stream)
 
 	// scan the stream from the serial port
 	scanner := bufio.NewScanner(stream)


### PR DESCRIPTION
This fixes the error `invalid operation: cannot close non-channel stream (variable of type *serial.Port)` when trying to execute `go run ./utils/read_serial.go`.